### PR TITLE
Fix overridden fetch_trend_data

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,14 +24,6 @@ from prometheus_client import start_http_server
 
 # Import text for raw SQL expressions
 
-def fetch_trend_data(business_idea: str, region: str) -> dict:
-    """
-    Mock function to fetch trend data for a given business idea and region.
-    Replace this with actual implementation.
-    """
-    # Mock data
-    return {"popularity": 75}
-
 def extract_region(location: str) -> str:
     """
     Extracts the region code from a location string.


### PR DESCRIPTION
## Summary
- remove duplicate `fetch_trend_data` implementation so the API version is used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google_reauth')*

------
https://chatgpt.com/codex/tasks/task_e_6841a754d54c8325b25076eef6604925